### PR TITLE
Update nuke.c

### DIFF
--- a/nuke.c
+++ b/nuke.c
@@ -56,4 +56,6 @@ int main() {
 #endif
 
     reset_usb_boot(0, 0);
+    // write to the magic address that triggers the UF2 bootloader.
+    *(volatile uint32_t *)(XIP_BASE + 0x10) = 0x00000000; 
 }


### PR DESCRIPTION
Update the image to run UF2 bootloader after reset.

I want to use this as part of the `mpflash` tool,  and without a reset into the bootloader, a user will need need to press the bootloader button, at just the right time.
With this change the mpflash can just proceed with updating the firmware to the requested version.

for  manual use I also think that in the vast majority of cases the next action will be for a user to update the MCU with a new firmware, and it would be mostly helpful if the board is already in the correct state to receive that.

Tested on: 
 - [ ]  PICO 
 - [ ]  PICO_W 
 - [x]  PICO2 
 - [ ]  PICO2 _W
  